### PR TITLE
[*] Direction-independent input of loads.

### DIFF
--- a/src/TestFEM.jl
+++ b/src/TestFEM.jl
@@ -36,13 +36,13 @@ function small_example()
 end
 
 function quarter_example()
-    answer_example_path = "examples/QuarterPlate/Quarter_Answer"
+    answer_path = "examples/QuarterPlate/Quarter_Answer"
     answer = readdlm(answer_path, '\t', Float64, '\n')
     return answer
 end
 
 function quarter8N_example()
-    answer_example_path = "examples/QuarterPlate8N/QuarterPlate8N_Answer"
+    answer_path = "examples/QuarterPlate8N/QuarterPlate8N_Answer"
     answer = readdlm(answer_path, '\t', Float64, '\n')
     return answer
 end

--- a/src/core/CoreFEM.jl
+++ b/src/core/CoreFEM.jl
@@ -143,7 +143,6 @@ function fem2D(meshPath::String, dataPath::String, elemTypeID::FETypes)
     parameters = processPars(testMaterialProperties(), testBC(), testLoad(), generateTestMesh2D(2))
     readParameters!(dataPath, parameters)
     parameters.mesh = readMeshFromSalomeDAT(meshPath, meshType)
-    printProcessPars(parameters)
     intOrder = 3
     nu = parameters.materialProperties[poisC]
     E = parameters.materialProperties[youngMod]

--- a/src/core/CoreFEM.jl
+++ b/src/core/CoreFEM.jl
@@ -143,7 +143,7 @@ function fem2D(meshPath::String, dataPath::String, elemTypeID::FETypes)
     parameters = processPars(testMaterialProperties(), testBC(), testLoad(), generateTestMesh2D(2))
     readParameters!(dataPath, parameters)
     parameters.mesh = readMeshFromSalomeDAT(meshPath, meshType)
-    # printProcessPars(parameters)
+    printProcessPars(parameters)
     intOrder = 3
     nu = parameters.materialProperties[poisC]
     E = parameters.materialProperties[youngMod]

--- a/src/core/Load.jl
+++ b/src/core/Load.jl
@@ -81,21 +81,25 @@ function elementLoad(elementNum::Int, pars::processPars, inputLoad::Array, loadD
     xCoords = [pars.mesh.nodes[pars.mesh.elements[elementNum][i]][1] for i in 1:nodesPerElement]
     yCoords = [pars.mesh.nodes[pars.mesh.elements[elementNum][i]][2] for i in 1:nodesPerElement]
     load = inputLoad
-    # IntegrationOrder = 4
-    FIntegrate(x) = 0
+
+    f_integrate_top(r) = transpose(displInterpMatr(r, 1, elemTypeInd)) * load * DetJs(r, 1, xCoords, yCoords, elemTypeInd)
+    f_integrate_left(s) = transpose(displInterpMatr(-1, s, elemTypeInd)) * load * DetJs(-1, s, xCoords, yCoords, elemTypeInd)
+    f_integrate_bottom(r) = transpose(displInterpMatr(r, -1, elemTypeInd)) * load * DetJs(r, -1, xCoords, yCoords, elemTypeInd)
+    f_integrate_right(s) = transpose(displInterpMatr(1, s, elemTypeInd)) * load * DetJs(1, s, xCoords, yCoords, elemTypeInd)
+
+    F = nothing
     if loadDirect == top
-        FIntegrate(r) = transpose(displInterpMatr(r, 1, elemTypeInd)) * load * DetJs(r, 1, xCoords, yCoords, elemTypeInd)
+        F = multipleIntegral.gauss1DMethodMatrix(f_integrate_top, intOrder)
     elseif loadDirect == left
-        FIntegrate(s) = transpose(displInterpMatr(-1, s, elemTypeInd)) * load * DetJs(-1, s, xCoords, yCoords, elemTypeInd)
+        F = multipleIntegral.gauss1DMethodMatrix(f_integrate_left, intOrder)
     elseif loadDirect == bottom
-        FIntegrate(r) = transpose(displInterpMatr(r, -1, elemTypeInd)) * load * DetJs(r, -1, xCoords, yCoords, elemTypeInd)
+        F = multipleIntegral.gauss1DMethodMatrix(f_integrate_bottom, intOrder)
     elseif loadDirect == right
-        FIntegrate(s) = transpose(displInterpMatr(1, s, elemTypeInd)) * load * DetJs(1, s, xCoords, yCoords, elemTypeInd)
+        F = multipleIntegral.gauss1DMethodMatrix(f_integrate_right, intOrder)
     else
-        println("Given load direction is not supported")
-        return nothing
+        @error("Given load direction is not supported")
     end
-    F = multipleIntegral.gauss1DMethodMatrix(FIntegrate, intOrder)
+
     return F
 end  # elementLoad
 

--- a/src/core/Load.jl
+++ b/src/core/Load.jl
@@ -82,10 +82,10 @@ function elementLoad(elementNum::Int, pars::processPars, inputLoad::Array, loadD
     yCoords = [pars.mesh.nodes[pars.mesh.elements[elementNum][i]][2] for i in 1:nodesPerElement]
     load = inputLoad
 
-    f_integrate_top(r) = transpose(displInterpMatr(r, 1, elemTypeInd)) * load * DetJs(r, 1, xCoords, yCoords, elemTypeInd)
-    f_integrate_left(s) = transpose(displInterpMatr(-1, s, elemTypeInd)) * load * DetJs(-1, s, xCoords, yCoords, elemTypeInd)
-    f_integrate_bottom(r) = transpose(displInterpMatr(r, -1, elemTypeInd)) * load * DetJs(r, -1, xCoords, yCoords, elemTypeInd)
-    f_integrate_right(s) = transpose(displInterpMatr(1, s, elemTypeInd)) * load * DetJs(1, s, xCoords, yCoords, elemTypeInd)
+    f_integrate_top(r) = transpose(displInterpMatr(r, 1, elemTypeInd)) * load * DetJs(r, 1, xCoords, yCoords, Int(loadDirect), elemTypeInd)
+    f_integrate_left(s) = transpose(displInterpMatr(-1, s, elemTypeInd)) * load * DetJs(-1, s, xCoords, yCoords, Int(loadDirect), elemTypeInd)
+    f_integrate_bottom(r) = transpose(displInterpMatr(r, -1, elemTypeInd)) * load * DetJs(r, -1, xCoords, yCoords, Int(loadDirect), elemTypeInd)
+    f_integrate_right(s) = transpose(displInterpMatr(1, s, elemTypeInd)) * load * DetJs(1, s, xCoords, yCoords, Int(loadDirect), elemTypeInd)
 
     F = nothing
     if loadDirect == top

--- a/src/core/Load.jl
+++ b/src/core/Load.jl
@@ -118,33 +118,25 @@ function assembly_loads!(pars::processPars, intOrder::Int, elemTypeInd::FiniteEl
     loadsVector = zeros(Float64, 2 * size(pars.mesh.nodes)[1])
     for (element, load) in pars.load
         elNum = element[1]
-        # @info("Element number:")
-        # println(elNum)
-
         # Global nodes to which load should be applied
         loadGlobalNodes = [element[i] for i in 3:size(element)[1]]
-        @info("Load global nodes:")
-        println(loadGlobalNodes)
 
         # Getting local numeration from given global one
         elNodes = pars.mesh.elements[elNum]
-        # @info("Element nodes:")
-        # println(elNodes)
         loadLocalNodes = zeros(Int, size(loadGlobalNodes)[1])
         for i in 1:size(loadGlobalNodes)[1]
             loadLocalNodes[i] = findall(x -> x == loadGlobalNodes[i], elNodes)[1]
         end
 
-        # direction = loadDirection(element[2])
         direction = loadDirection(directionFromNodes(loadLocalNodes, elemTypeInd))
         F = elementLoad(elNum, pars, load, direction, intOrder, elemTypeInd)
         loadLocalNodes = nodesFromDirection(Int(direction), elemTypeInd)
-        @info("Load local nodes:")
-        println(loadLocalNodes)
+
         if (size(element)[1] - 2 != size(loadLocalNodes)[1])
             @error "Incorrect input load"
             return nothing
         end
+        
         for i in eachindex(loadLocalNodes)
             localIndex = loadLocalNodes[i]
             globalIndex = loadGlobalNodes[i]

--- a/src/core/Load.jl
+++ b/src/core/Load.jl
@@ -114,14 +114,33 @@ function assembly_loads!(pars::processPars, intOrder::Int, elemTypeInd::FiniteEl
     loadsVector = zeros(Float64, 2 * size(pars.mesh.nodes)[1])
     for (element, load) in pars.load
         elNum = element[1]
-        direction = loadDirection(element[2])
+        # @info("Element number:")
+        # println(elNum)
+
+        # Global nodes to which load should be applied
+        loadGlobalNodes = [element[i] for i in 3:size(element)[1]]
+        @info("Load global nodes:")
+        println(loadGlobalNodes)
+
+        # Getting local numeration from given global one
+        elNodes = pars.mesh.elements[elNum]
+        # @info("Element nodes:")
+        # println(elNodes)
+        loadLocalNodes = zeros(Int, size(loadGlobalNodes)[1])
+        for i in 1:size(loadGlobalNodes)[1]
+            loadLocalNodes[i] = findall(x -> x == loadGlobalNodes[i], elNodes)[1]
+        end
+
+        # direction = loadDirection(element[2])
+        direction = loadDirection(directionFromNodes(loadLocalNodes, elemTypeInd))
         F = elementLoad(elNum, pars, load, direction, intOrder, elemTypeInd)
         loadLocalNodes = nodesFromDirection(Int(direction), elemTypeInd)
+        @info("Load local nodes:")
+        println(loadLocalNodes)
         if (size(element)[1] - 2 != size(loadLocalNodes)[1])
             @error "Incorrect input load"
             return nothing
         end
-        loadGlobalNodes = [element[i] for i in 3:size(element)[1]]
         for i in eachindex(loadLocalNodes)
             localIndex = loadLocalNodes[i]
             globalIndex = loadGlobalNodes[i]

--- a/src/core/interpolation/Quad4Pts.jl
+++ b/src/core/interpolation/Quad4Pts.jl
@@ -99,7 +99,14 @@ Determinant of appropriate Jacobi matrix.
 - `xCoords::Array{Float64}`: x coordinates of each node in current element;
 - `yCoords::Array{Float64}`: y coordinates of each node in current element.
 """
-ElementTypes.DetJs(r, s, xCoords::Array{Float64}, yCoords::Array{Float64}, elemTypeInd::Quad4Type) = sqrt(dxs(r, s, xCoords)^2 + dys(r, s, yCoords)^2)
+function ElementTypes.DetJs(r, s, xCoords::Array{Float64}, yCoords::Array{Float64}, elemTypeInd::Quad4Type)
+
+    # TODO: Unify method for every possible set of nodes
+
+    return sqrt(dxs(r, s, xCoords)^2 + dys(r, s, yCoords)^2)
+    # return sqrt(dxr(r, s, xCoords)^2 + dyr(r, s, yCoords)^2)
+end
+
 
 dh1x(r, s, xCoords::Array{Float64}, yCoords::Array{Float64}) = jacGlobToLocInv(r, s, xCoords, yCoords)[1, 1] * dh1r(r, s) + jacGlobToLocInv(r, s, xCoords, yCoords)[1, 2] * dh1s(r, s)
 dh1y(r, s, xCoords::Array{Float64}, yCoords::Array{Float64}) = jacGlobToLocInv(r, s, xCoords, yCoords)[2, 1] * dh1r(r, s) + jacGlobToLocInv(r, s, xCoords, yCoords)[2, 2] * dh1s(r, s)
@@ -150,10 +157,17 @@ Displacements interpolation ``H`` matrix.
 """
 function ElementTypes.displInterpMatr(r, s, elemTypeInd::Quad4Type)
     result = zeros(Real, 2, 8)
+
+    # TODO: Unify method for every possible set of nodes
+
     result[1, 1] = 0.5 * (1 + s)
     result[1, 7] = 0.5 * (1 - s)
     result[2, 2] = 0.5 * (1 + s)
     result[2, 8] = 0.5 * (1 - s)
+    # result[1, 1] = 0.5 * (1 + r)
+    # result[1, 3] = 0.5 * (1 - r)
+    # result[2, 2] = 0.5 * (1 + r)
+    # result[2, 4] = 0.5 * (1 - r)
     return result
 end  # displInterpMatr
 
@@ -189,16 +203,14 @@ Return direction from given nodes.
 - `nodes::Array`: nodes according to which direction should be defined.
 - `elType:: FiniteElement`: element type indicator.
 """
-function ElementTypes.directionFromNodes(nodes::Array, elType:: FiniteElement)
+function ElementTypes.directionFromNodes(nodes::Array, elemTypeInd::Quad4Type)
     if issubset([1, 2], nodes)
-        @info("[1, 2] found")
-        return 4  # Top
+        return 1  # Top
     elseif issubset([3, 2], nodes)  # TODO: provide order-insensetive way to define direction
-        # return 2  # Left            # Now it only works for [3, 2] case.
-        return 4
+        return 2  # Left            # Now it only works for [3, 2] case.
     elseif issubset([3, 4], nodes)
         return 3  # Bottom
-    elseif issubset([5, 6], nodes)
+    elseif issubset([1, 4], nodes)
         return 4  # Right
     else
         @error("Can't define direction from given nodes")

--- a/src/core/interpolation/Quad4Pts.jl
+++ b/src/core/interpolation/Quad4Pts.jl
@@ -97,14 +97,19 @@ Determinant of appropriate Jacobi matrix.
 - `r`: r-coordinate;
 - `s`: s-coordinate;
 - `xCoords::Array{Float64}`: x coordinates of each node in current element;
-- `yCoords::Array{Float64}`: y coordinates of each node in current element.
+- `yCoords::Array{Float64}`: y coordinates of each node in current element;
+- `load_direction::Int`: direction of load;
+- `elemTypeInd::Quad4Type`: type of finite element indicator.
 """
-function ElementTypes.DetJs(r, s, xCoords::Array{Float64}, yCoords::Array{Float64}, elemTypeInd::Quad4Type)
-
-    # TODO: Unify method for every possible set of nodes
-
-    return sqrt(dxs(r, s, xCoords)^2 + dys(r, s, yCoords)^2)
-    # return sqrt(dxr(r, s, xCoords)^2 + dyr(r, s, yCoords)^2)
+function ElementTypes.DetJs(r, s, xCoords::Array{Float64}, yCoords::Array{Float64}, load_direction::Int, elemTypeInd::Quad4Type)
+    if load_direction == 1 || load_direction == 3
+        return sqrt(dxr(r, s, xCoords)^2 + dyr(r, s, yCoords)^2)
+    elseif load_direction == 2 || load_direction == 4
+        return sqrt(dxs(r, s, xCoords)^2 + dys(r, s, yCoords)^2)
+    else
+        @error("Incorrect direction while calculating \"surface\" Jacobian")
+        return nothing
+    end
 end
 
 

--- a/src/core/interpolation/Quad4Pts.jl
+++ b/src/core/interpolation/Quad4Pts.jl
@@ -145,7 +145,6 @@ function ElementTypes.gradMatr(r, s, xCoords::Array{Float64}, yCoords::Array{Flo
     return resultMatrix
 end
 
-# Precalculated displacements interpolation H matrix
 """
     displInterpMatr(r, s)
 
@@ -153,21 +152,13 @@ Displacements interpolation ``H`` matrix.
 
 # Arguments
 - `r`: r-coordinate;
-- `s`: s-coordinate.
+- `s`: s-coordinate;
+- `elemTypeInd::Quad4Type`: type of finite element indicator.
 """
 function ElementTypes.displInterpMatr(r, s, elemTypeInd::Quad4Type)
-    result = zeros(Real, 2, 8)
+    result = [  h1(r, s)   0   h2(r, s)    0   h3(r, s)    0    h4(r, s)    0
+                0       h1(r, s)    0   h2(r, s)    0   h3(r, s)    0       h4(r, s)]
 
-    # TODO: Unify method for every possible set of nodes
-
-    result[1, 1] = 0.5 * (1 + s)
-    result[1, 7] = 0.5 * (1 - s)
-    result[2, 2] = 0.5 * (1 + s)
-    result[2, 8] = 0.5 * (1 - s)
-    # result[1, 1] = 0.5 * (1 + r)
-    # result[1, 3] = 0.5 * (1 - r)
-    # result[2, 2] = 0.5 * (1 + r)
-    # result[2, 4] = 0.5 * (1 - r)
     return result
 end  # displInterpMatr
 

--- a/src/core/interpolation/Quad4Pts.jl
+++ b/src/core/interpolation/Quad4Pts.jl
@@ -8,7 +8,7 @@ module Quad4Pts
 using ElementTypes
 
 export FiniteElement, Quad4Type
-export jacGlobToLoc, DetJs, gradMatr, displInterpMatr, nodesFromDirection, getRSFromNode
+export jacGlobToLoc, DetJs, gradMatr, displInterpMatr, nodesFromDirection, directionFromNodes, getRSFromNode
 
 struct Quad4Type <: FiniteElement
     name::String
@@ -179,6 +179,32 @@ function ElementTypes.nodesFromDirection(direction::Int, elemTypeInd::Quad4Type)
         return nothing
     end
 end  # nodesFromDirection
+
+"""
+    directionFromNodes(nodes::Array, elType:: FiniteElement)
+
+Return direction from given nodes.
+
+# Arguments
+- `nodes::Array`: nodes according to which direction should be defined.
+- `elType:: FiniteElement`: element type indicator.
+"""
+function ElementTypes.directionFromNodes(nodes::Array, elType:: FiniteElement)
+    if issubset([1, 2], nodes)
+        @info("[1, 2] found")
+        return 4  # Top
+    elseif issubset([3, 2], nodes)  # TODO: provide order-insensetive way to define direction
+        # return 2  # Left            # Now it only works for [3, 2] case.
+        return 4
+    elseif issubset([3, 4], nodes)
+        return 3  # Bottom
+    elseif issubset([5, 6], nodes)
+        return 4  # Right
+    else
+        @error("Can't define direction from given nodes")
+        return nothing
+    end
+end  # directionFromNodes
 
 function ElementTypes.getRSFromNode(nodeIndex::Int, elemTypeInd::Quad4Type)
     if nodeIndex == 1

--- a/src/mesh/Mesh_T.jl
+++ b/src/mesh/Mesh_T.jl
@@ -84,16 +84,24 @@ Renumerate nodes in each element according to FEM model.
 """
 function renumerateNodes!(mesh::Mesh2D_T, type::meshType)
     for i in eachindex(mesh.elements)
-        # TODO: make auto-renumeration
         x = [mesh.nodes[mesh.elements[i][1]][1], mesh.nodes[mesh.elements[i][2]][1], mesh.nodes[mesh.elements[i][3]][1], mesh.nodes[mesh.elements[i][4]][1]]
         y = [mesh.nodes[mesh.elements[i][1]][2], mesh.nodes[mesh.elements[i][2]][2], mesh.nodes[mesh.elements[i][3]][2], mesh.nodes[mesh.elements[i][4]][2]]
         newNodes = nothing
         if type === Quad4Pts2D
+            # All possible renumerations
             newNodes = (mesh.elements[i][1], mesh.elements[i][4], mesh.elements[i][3], mesh.elements[i][2])
             # newNodes = (mesh.elements[i][4], mesh.elements[i][3], mesh.elements[i][2], mesh.elements[i][1])
             # newNodes = (mesh.elements[i][3], mesh.elements[i][2], mesh.elements[i][1], mesh.elements[i][4])
+            # newNodes = (mesh.elements[i][2], mesh.elements[i][1], mesh.elements[i][4], mesh.elements[i][3])
         elseif type === Quad8Pts2D
+            # TODO: This works not for every mesh generated in Salome.
+            # Need to check how Salome actually numerates nodes for such finite element.
+
+            # All possible renumerations
             newNodes = (mesh.elements[i][3], mesh.elements[i][2], mesh.elements[i][1], mesh.elements[i][4], mesh.elements[i][6], mesh.elements[i][5], mesh.elements[i][8], mesh.elements[i][7])
+            # newNodes = (mesh.elements[i][2], mesh.elements[i][1], mesh.elements[i][4], mesh.elements[i][3], mesh.elements[i][5], mesh.elements[i][8], mesh.elements[i][7], mesh.elements[i][6])
+            # newNodes = (mesh.elements[i][1], mesh.elements[i][4], mesh.elements[i][3], mesh.elements[i][2], mesh.elements[i][8], mesh.elements[i][7], mesh.elements[i][6], mesh.elements[i][5])
+            # newNodes = (mesh.elements[i][4], mesh.elements[i][3], mesh.elements[i][2], mesh.elements[i][1], mesh.elements[i][7], mesh.elements[i][6], mesh.elements[i][5], mesh.elements[i][8])
         else
             println("Unknown mesh type while renumerating nodes")
         end

--- a/src/mesh/Mesh_T.jl
+++ b/src/mesh/Mesh_T.jl
@@ -89,9 +89,9 @@ function renumerateNodes!(mesh::Mesh2D_T, type::meshType)
         y = [mesh.nodes[mesh.elements[i][1]][2], mesh.nodes[mesh.elements[i][2]][2], mesh.nodes[mesh.elements[i][3]][2], mesh.nodes[mesh.elements[i][4]][2]]
         newNodes = nothing
         if type === Quad4Pts2D
-            # newNodes = (mesh.elements[i][1], mesh.elements[i][4], mesh.elements[i][3], mesh.elements[i][2])
+            newNodes = (mesh.elements[i][1], mesh.elements[i][4], mesh.elements[i][3], mesh.elements[i][2])
             # newNodes = (mesh.elements[i][4], mesh.elements[i][3], mesh.elements[i][2], mesh.elements[i][1])
-            newNodes = (mesh.elements[i][3], mesh.elements[i][2], mesh.elements[i][1], mesh.elements[i][4])
+            # newNodes = (mesh.elements[i][3], mesh.elements[i][2], mesh.elements[i][1], mesh.elements[i][4])
         elseif type === Quad8Pts2D
             newNodes = (mesh.elements[i][3], mesh.elements[i][2], mesh.elements[i][1], mesh.elements[i][4], mesh.elements[i][6], mesh.elements[i][5], mesh.elements[i][8], mesh.elements[i][7])
         else

--- a/src/mesh/Mesh_T.jl
+++ b/src/mesh/Mesh_T.jl
@@ -90,7 +90,8 @@ function renumerateNodes!(mesh::Mesh2D_T, type::meshType)
         newNodes = nothing
         if type === Quad4Pts2D
             # newNodes = (mesh.elements[i][1], mesh.elements[i][4], mesh.elements[i][3], mesh.elements[i][2])
-            newNodes = (mesh.elements[i][4], mesh.elements[i][3], mesh.elements[i][2], mesh.elements[i][1])
+            # newNodes = (mesh.elements[i][4], mesh.elements[i][3], mesh.elements[i][2], mesh.elements[i][1])
+            newNodes = (mesh.elements[i][3], mesh.elements[i][2], mesh.elements[i][1], mesh.elements[i][4])
         elseif type === Quad8Pts2D
             newNodes = (mesh.elements[i][3], mesh.elements[i][2], mesh.elements[i][1], mesh.elements[i][4], mesh.elements[i][6], mesh.elements[i][5], mesh.elements[i][8], mesh.elements[i][7])
         else

--- a/src/mesh/Mesh_T.jl
+++ b/src/mesh/Mesh_T.jl
@@ -89,7 +89,8 @@ function renumerateNodes!(mesh::Mesh2D_T, type::meshType)
         y = [mesh.nodes[mesh.elements[i][1]][2], mesh.nodes[mesh.elements[i][2]][2], mesh.nodes[mesh.elements[i][3]][2], mesh.nodes[mesh.elements[i][4]][2]]
         newNodes = nothing
         if type === Quad4Pts2D
-            newNodes = (mesh.elements[i][1], mesh.elements[i][4], mesh.elements[i][3], mesh.elements[i][2])
+            # newNodes = (mesh.elements[i][1], mesh.elements[i][4], mesh.elements[i][3], mesh.elements[i][2])
+            newNodes = (mesh.elements[i][4], mesh.elements[i][3], mesh.elements[i][2], mesh.elements[i][1])
         elseif type === Quad8Pts2D
             newNodes = (mesh.elements[i][3], mesh.elements[i][2], mesh.elements[i][1], mesh.elements[i][4], mesh.elements[i][6], mesh.elements[i][5], mesh.elements[i][8], mesh.elements[i][7])
         else

--- a/src/types/ElementTypes.jl
+++ b/src/types/ElementTypes.jl
@@ -17,7 +17,7 @@ abstract type FiniteElement end
 
 jacGlobToLoc(r, s, xCoords::Array{Float64}, yCoords::Array{Float64}, elType::FiniteElement) = nothing
 
-DetJs(r, s, xCoords::Array{Float64}, yCoords::Array{Float64}, elType::FiniteElement) = nothing
+DetJs(r, s, xCoords::Array{Float64}, yCoords::Array{Float64}, load_direction::Int, elType::FiniteElement) = nothing
 
 gradMatr(r, s, xCoords::Array{Float64}, yCoords::Array{Float64}, elType::FiniteElement) = nothing
 

--- a/src/types/ElementTypes.jl
+++ b/src/types/ElementTypes.jl
@@ -2,7 +2,7 @@ module ElementTypes
 
 export FiniteElement
 
-export jacGlobToLoc, DetJs, gradMatr, displInterpMatr, nodesFromDirection, getRSFromNode
+export jacGlobToLoc, DetJs, gradMatr, displInterpMatr, nodesFromDirection, directionFromNodes, getRSFromNode
 
 # TODO: Write macro to export whole enum at once
 export FETypes, Quad4TypeID, Quad8TypeID
@@ -24,6 +24,7 @@ gradMatr(r, s, xCoords::Array{Float64}, yCoords::Array{Float64}, elType::FiniteE
 displInterpMatr(r, s) = nothing
 
 nodesFromDirection(direction::Int, elType::FiniteElement) = nothing
+directionFromNodes(nodes::Array, elType:: FiniteElement) = nothing
 
 getRSFromNode(nodeIndex::Int) = nothing
 


### PR DESCRIPTION
- assembly_loads!() now takes only nodes and calculate direction by itself.
- Fixed top, left and bottom cases of load application.
- Unified displnterpolateMatr() in Quad4Pts.
- Unfiied detJs() methods.